### PR TITLE
Feature/add prelude map func

### DIFF
--- a/pkg/codegen/prelude.go
+++ b/pkg/codegen/prelude.go
@@ -11,6 +11,7 @@ var PreludeFunction = map[string]func(*Context, *mTypes.Node) value.Value{
 	mTypes.PRELUDE_GET:  PreludeGet,
 	mTypes.PRELUDE_NTH:  PreludeNth,
 	mTypes.PRELUDE_CONJ: PreludeConj,
+	mTypes.PRELUDE_MAP:  PreludeMap,
 	//mTypes.LIB_CORE_ASSOC: PreludeAssoc,
 	//mTypes.LIB_CORE_POP:   PreludePop,
 	// nary

--- a/pkg/codegen/prelude_map.go
+++ b/pkg/codegen/prelude_map.go
@@ -18,6 +18,8 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	}
 	var f *ir.Func
 
+	// find declared function
+	// TODO: find also in prelude function
 	for i := 0; i < len(ctx.mod.Funcs); i = i + 1 {
 		if ctx.mod.Funcs[i].GlobalName == n.GetFuncName() {
 			f = ctx.mod.Funcs[i]
@@ -32,7 +34,7 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
 	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)
 
-	/////
+	// create a new vector which element are applied by specified function
 	oldVecPtr := ctx.block.NewExtractValue(oldStructedVec, 0)
 
 	elemSize := constant.NewInt(types.I64, int64(mTypes.GetBitWidth(elemType)))
@@ -44,9 +46,9 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	loopIndex := ctx.block.NewAlloca(types.I64)
 	ctx.block.NewStore(mTypes.I64zero, loopIndex)
 
-	loopBlock := ctx.function.NewBlock(n.GetBlockName("copy.loop", ctx.function.Blocks))
-	condBlock := ctx.function.NewBlock(n.GetBlockName("copy.cond", ctx.function.Blocks))
-	endBlock := ctx.function.NewBlock(n.GetBlockName("copy.end", ctx.function.Blocks))
+	loopBlock := ctx.function.NewBlock(n.GetBlockName("map.loop", ctx.function.Blocks))
+	condBlock := ctx.function.NewBlock(n.GetBlockName("map.cond", ctx.function.Blocks))
+	endBlock := ctx.function.NewBlock(n.GetBlockName("map.end", ctx.function.Blocks))
 
 	ctx.block.NewBr(condBlock)
 
@@ -65,7 +67,7 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	loopBlock.NewBr(condBlock)
 
 	ctx.block = endBlock
-	/////
+	// loop end
 
 	newStructVecType := mTypes.DeclareVectorType(
 		ctx.mod,

--- a/pkg/codegen/prelude_map.go
+++ b/pkg/codegen/prelude_map.go
@@ -67,10 +67,15 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	ctx.block = endBlock
 	/////
 
-	newStructAlloca := ctx.block.NewAlloca(structedVecType)
+	newStructVecType := mTypes.DeclareVectorType(
+		ctx.mod,
+		elemType,
+		&mTypes.NodeType{Value: mTypes.TY_VECTOR},
+	)
+	newStructAlloca := ctx.block.NewAlloca(newStructVecType)
 
 	newVecField := ctx.block.NewGetElementPtr(
-		structedVecType,
+		newStructVecType,
 		newStructAlloca,
 		mTypes.I32zero,
 		mTypes.I32zero,
@@ -78,7 +83,7 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	ctx.block.NewStore(newVecPtr, newVecField)
 
 	newLenField := ctx.block.NewGetElementPtr(
-		structedVecType,
+		newStructVecType,
 		newStructAlloca,
 		mTypes.I32zero,
 		mTypes.I32one,

--- a/pkg/codegen/prelude_map.go
+++ b/pkg/codegen/prelude_map.go
@@ -1,0 +1,89 @@
+package codegen
+
+import (
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/enum"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
+
+	"github.com/wf001/modo/pkg/error"
+	"github.com/wf001/modo/pkg/log"
+	mTypes "github.com/wf001/modo/pkg/types"
+)
+
+func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
+	if !n.IsKind(mTypes.ND_VAR_REFERENCE) {
+		log.Panic("%s: unexpected character used", error.ERROR_SYNTAX_ERROR)
+	}
+	var f *ir.Func
+
+	for i := 0; i < len(ctx.mod.Funcs); i = i + 1 {
+		if ctx.mod.Funcs[i].GlobalName == n.GetFuncName() {
+			f = ctx.mod.Funcs[i]
+			break
+		}
+	}
+
+	oldStructedVecPtr := n.Next.IRValue
+	structedVecType := mTypes.GetStructTypeFromPtr(oldStructedVecPtr)
+	elemType := f.Sig.RetType
+
+	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
+	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)
+
+	/////
+	oldVecPtr := ctx.block.NewExtractValue(oldStructedVec, 0)
+
+	elemSize := constant.NewInt(types.I64, int64(mTypes.GetBitWidth(elemType)))
+	newVecAllocSize := ctx.block.NewMul(elemSize, oldLen)
+
+	newVecAllocPtr := ctx.block.NewCall(ctx.internal.Cstd.Malloc, newVecAllocSize)
+	newVecPtr := ctx.block.NewBitCast(newVecAllocPtr, types.NewPointer(elemType))
+
+	loopIndex := ctx.block.NewAlloca(types.I64)
+	ctx.block.NewStore(mTypes.I64zero, loopIndex)
+
+	loopBlock := ctx.function.NewBlock(n.GetBlockName("copy.loop", ctx.function.Blocks))
+	condBlock := ctx.function.NewBlock(n.GetBlockName("copy.cond", ctx.function.Blocks))
+	endBlock := ctx.function.NewBlock(n.GetBlockName("copy.end", ctx.function.Blocks))
+
+	ctx.block.NewBr(condBlock)
+
+	idx := condBlock.NewLoad(types.I64, loopIndex)
+	copyContinue := condBlock.NewICmp(enum.IPredULT, idx, oldLen)
+	condBlock.NewCondBr(copyContinue, loopBlock, endBlock)
+
+	oldArrElemPtr := loopBlock.NewGetElementPtr(elemType, oldVecPtr, idx)
+	oldElem := loopBlock.NewLoad(elemType, oldArrElemPtr)
+	newElem := loopBlock.NewCall(f, oldElem)
+	newVecElemPtr := loopBlock.NewGetElementPtr(elemType, newVecPtr, idx)
+	loopBlock.NewStore(newElem, newVecElemPtr)
+
+	incI := loopBlock.NewAdd(idx, mTypes.I64one)
+	loopBlock.NewStore(incI, loopIndex)
+	loopBlock.NewBr(condBlock)
+
+	ctx.block = endBlock
+	/////
+
+	newStructAlloca := ctx.block.NewAlloca(structedVecType)
+
+	newVecField := ctx.block.NewGetElementPtr(
+		structedVecType,
+		newStructAlloca,
+		mTypes.I32zero,
+		mTypes.I32zero,
+	)
+	ctx.block.NewStore(newVecPtr, newVecField)
+
+	newLenField := ctx.block.NewGetElementPtr(
+		structedVecType,
+		newStructAlloca,
+		mTypes.I32zero,
+		mTypes.I32one,
+	)
+	ctx.block.NewStore(oldLen, newLenField)
+
+	return newStructAlloca
+}

--- a/pkg/types/lex.go
+++ b/pkg/types/lex.go
@@ -85,14 +85,16 @@ var (
 	PRELUDE_CONJ             = "conj"
 	PRELUDE_ASSOC            = "assoc"
 	PRELUDE_POP              = "pop"
+	PRELUDE_MAP              = "map"
 	PRELUDE_FUNCTION_REG_EXP = fmt.Sprintf(
-		"\\b(%s|%s|%s|%s|%s|%s)\\b",
+		"\\b(%s|%s|%s|%s|%s|%s|%s)\\b",
 		PRELUDE_PRN,
 		PRELUDE_GET,
 		PRELUDE_NTH,
 		PRELUDE_CONJ,
 		PRELUDE_ASSOC,
 		PRELUDE_POP,
+		PRELUDE_MAP,
 	)
 
 	// Type signature

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -195,7 +195,7 @@ func isStructTypeDefined(mod *ir.Module, fields []types.Type) (types.Type, bool)
 	return nil, false
 }
 
-func declareVectorType(ir *ir.Module, ty types.Type, ndtype *NodeType) types.Type {
+func DeclareVectorType(ir *ir.Module, ty types.Type, ndtype *NodeType) types.Type {
 	// i32 type vector
 	// 型: struct { i32* %arrElm, i64 %len}
 	vectorIntType := types.NewStruct(types.NewPointer(ty), types.I64)
@@ -235,7 +235,7 @@ func GetLLVMTypeRec(
 
 	if ndtype.Value == TY_VECTOR {
 		chidType, _, _ := GetLLVMTypeRec(m, ndtype.Child, prelude)
-		ret := declareVectorType(m, chidType, ndtype)
+		ret := DeclareVectorType(m, chidType, ndtype)
 		return ret, chidType, true
 	}
 

--- a/script/test-full.sh
+++ b/script/test-full.sh
@@ -202,6 +202,10 @@ testexec(){
   # pop
   # assertexec '(def main :: int (fn [] (let [vec :: [int] [423, 83, 90]] (prn (pop vec)) (prn vec))))'  "[423, 83]\\\n[423, 83, 90]\\\n"
   # assertexec '(def v :: [int] [233, 842]) (def main :: int (fn [] (prn (pop v))))' "[233]\\\n"
+  # map
+  assertexec "(def inc :: int => int (fn [x] (+ x 1))) (def main :: int (fn [] (prn (map inc [32 13 99]))))" "[33, 14, 100]\\\n"
+  assertexec '(def str :: int => string (fn [x] "a")) (def main :: int (fn [] (prn (map str [32 13 99]))))' "[a, a, a]\\\n"
+  assertexec '(def truely :: int => bool (fn [x] true)) (def main :: int (fn [] (prn (map truely [32 13 99]))))' "[true, true, true]\\\n"
 
   # argument and return
   assertexec "(def f::[int] => nil (fn[v] (prn v))) (def main::int (fn[] (let[v::[int][42, 64, 90]] (f v))))" "[42, 64, 90]\\\n"


### PR DESCRIPTION
## What’s this PR?

- add map function, used like `map f coll`

## What’s changed?

## Anything else?
- Unlike clojure's one, modo map takes only one collection
- NOT support taking operator function, like `+`, `-`
