### PR TITLE
Feature/share naming logic

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -470,7 +470,7 @@ func (ctx *Context) genBranch(
 
 func (ctx *Context) genCondition(node *mTypes.Node) {
 	// cond
-	condBlock := ctx.function.NewBlock(node.GetBlockName("if.cond", ctx.function.Blocks))
+	condBlock := ctx.NewBlock("if.cond", node)
 	ctx.block.NewBr(condBlock)
 	ctx.block = condBlock
 	cond := ctx.gen(node.Cond)
@@ -485,7 +485,7 @@ func (ctx *Context) genCondition(node *mTypes.Node) {
 
 	// exit
 	// NOTE: is it the type truly?
-	exitBlock := ctx.function.NewBlock(node.GetBlockName("if.exit", ctx.function.Blocks))
+	exitBlock := ctx.NewBlock("if.exit", node)
 
 	if retType.Equal(types.Void) {
 		exitBlock.NewRet(nil)
@@ -495,11 +495,11 @@ func (ctx *Context) genCondition(node *mTypes.Node) {
 	}
 
 	// then
-	thenBlock := ctx.function.NewBlock(node.GetBlockName("if.then", ctx.function.Blocks))
+	thenBlock := ctx.NewBlock("if.then", node)
 	ctx.genBranch(thenBlock, node.Then, node.CondRet, exitBlock)
 
 	// else
-	elseBlock := ctx.function.NewBlock(node.GetBlockName("if.else", ctx.function.Blocks))
+	elseBlock := ctx.NewBlock("if.else", node)
 	ctx.genBranch(elseBlock, node.Else, node.CondRet, exitBlock)
 
 	condBlock.NewCondBr(cond, thenBlock, elseBlock)

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -409,7 +409,7 @@ func (ctx *Context) genLambda(node *mTypes.Node) value.Value {
 			types.Void,
 			ctx.function.Params...,
 		)
-		entryBlock := funcFn.NewBlock(node.GetBlockName(fnEntryBlockName, ctx.function.Blocks))
+		entryBlock := funcFn.NewBlock(ctx.GetBlockName(fnEntryBlockName, node))
 
 		ctx.function = funcFn
 		ctx.block = entryBlock
@@ -426,7 +426,7 @@ func (ctx *Context) genLambda(node *mTypes.Node) value.Value {
 			ctx.function.Sig.RetType,
 			ctx.function.Params...,
 		)
-		entryBlock := funcFn.NewBlock(node.GetBlockName(fnEntryBlockName, ctx.function.Blocks))
+		entryBlock := funcFn.NewBlock(ctx.GetBlockName(fnEntryBlockName, node))
 
 		ctx.function = funcFn
 		ctx.block = entryBlock

--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -147,7 +147,7 @@ func newVectorHeap(ctx *Context, n *mTypes.Node) value.Value {
 		mTypes.I32zero,
 		mTypes.I32zero,
 	)
-	vecElemPtr.SetName(n.GetVarName("new.vector.vec.elem.ptr", ctx.block.Insts))
+	vecElemPtr.SetName(n.GetVarName("new.vector.vec.elem.ptr"))
 	ctx.block.NewStore(vecPtr, vecElemPtr)
 
 	lenElemPtr := ctx.block.NewGetElementPtr(
@@ -156,7 +156,7 @@ func newVectorHeap(ctx *Context, n *mTypes.Node) value.Value {
 		mTypes.I32zero,
 		mTypes.I32one,
 	)
-	lenElemPtr.SetName(n.GetVarName("new.vector.len.elem.ptr", ctx.block.Insts))
+	lenElemPtr.SetName(n.GetVarName("new.vector.len.elem.ptr"))
 	ctx.block.NewStore(constant.NewInt(types.I64, vecLength), lenElemPtr)
 
 	return vecIntAlloca

--- a/pkg/codegen/context.go
+++ b/pkg/codegen/context.go
@@ -1,0 +1,11 @@
+package codegen
+
+import (
+	"github.com/llir/llvm/ir"
+
+	mTypes "github.com/wf001/modo/pkg/types"
+)
+
+func (ctx Context) NewBlock(name string, n *mTypes.Node) *ir.Block {
+	return ctx.function.NewBlock(n.GetBlockName(name, ctx.function.Blocks))
+}

--- a/pkg/codegen/context.go
+++ b/pkg/codegen/context.go
@@ -1,11 +1,17 @@
 package codegen
 
 import (
+	"fmt"
+
 	"github.com/llir/llvm/ir"
 
 	mTypes "github.com/wf001/modo/pkg/types"
 )
 
 func (ctx Context) NewBlock(name string, n *mTypes.Node) *ir.Block {
-	return ctx.function.NewBlock(n.GetBlockName(name, ctx.function.Blocks))
+	return ctx.function.NewBlock(ctx.GetBlockName(name, n))
+}
+
+func (ctx Context) GetBlockName(s string, node *mTypes.Node) string {
+	return fmt.Sprintf("%s.%p.%d", s, node, len(ctx.block.Insts))
 }

--- a/pkg/codegen/prelude_conj.go
+++ b/pkg/codegen/prelude_conj.go
@@ -10,8 +10,7 @@ import (
 func PreludeConj(ctx *Context, n *mTypes.Node) value.Value {
 	oldStructedVecPtr := n.IRValue
 
-	structedVecType := mTypes.GetStructTypeFromPtr(oldStructedVecPtr)
-	elemType := structedVecType.Fields[0].(*types.PointerType).ElemType
+	structedVecType, elemType := mTypes.GetVectorTypeFromPtr(oldStructedVecPtr)
 
 	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
 	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)

--- a/pkg/codegen/prelude_filter.go
+++ b/pkg/codegen/prelude_filter.go
@@ -51,9 +51,9 @@ func PreludeFilter(ctx *Context, n *mTypes.Node) value.Value {
 	ctx.block.NewBr(countCondBlock)
 
 	numTrue := countCondBlock.NewLoad(types.I64, numTruePtr)
-	numTrue.SetName(n.GetVarName("filter.count.true", ctx.block.Insts))
+	numTrue.SetName(n.GetVarName("filter.count.true"))
 	countloopIdx := countCondBlock.NewLoad(types.I64, countLoopIdxPtr)
-	countloopIdx.SetName(n.GetVarName("filter.count.loop.idx", ctx.block.Insts))
+	countloopIdx.SetName(n.GetVarName("filter.count.loop.idx"))
 
 	isIdxLTOldLen := countCondBlock.NewICmp(enum.IPredULT, countloopIdx, oldLen)
 	countCondBlock.NewCondBr(isIdxLTOldLen, countLoopBlock, countEndBlock)

--- a/pkg/codegen/prelude_filter.go
+++ b/pkg/codegen/prelude_filter.go
@@ -28,8 +28,7 @@ func PreludeFilter(ctx *Context, n *mTypes.Node) value.Value {
 	}
 
 	oldStructedVecPtr := n.Next.IRValue
-	structedVecType := mTypes.GetStructTypeFromPtr(oldStructedVecPtr)
-	elemType := structedVecType.Fields[0].(*types.PointerType).ElemType
+	structedVecType, elemType := mTypes.GetVectorTypeFromPtr(oldStructedVecPtr)
 
 	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
 	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)

--- a/pkg/codegen/prelude_filter.go
+++ b/pkg/codegen/prelude_filter.go
@@ -43,21 +43,11 @@ func PreludeFilter(ctx *Context, n *mTypes.Node) value.Value {
 	countLoopIdxPtr := ctx.block.NewAlloca(types.I64)
 	ctx.block.NewStore(mTypes.I64zero, countLoopIdxPtr)
 
-	countCondBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.count.cond", ctx.function.Blocks),
-	)
-	countLoopBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.count.loop", ctx.function.Blocks),
-	)
-	countLoopIncCountBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.count.loop.inc.count", ctx.function.Blocks),
-	)
-	countLoopIncIdxBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.count.loop.inc.idx", ctx.function.Blocks),
-	)
-	countEndBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.count.end", ctx.function.Blocks),
-	)
+	countCondBlock := ctx.NewBlock("filter.count.cond", n)
+	countLoopBlock := ctx.NewBlock("filter.count.loop", n)
+	countLoopIncCountBlock := ctx.NewBlock("filter.count.loop.inc.count", n)
+	countLoopIncIdxBlock := ctx.NewBlock("filter.count.loop.inc.idx", n)
+	countEndBlock := ctx.NewBlock("filter.count.end", n)
 
 	ctx.block.NewBr(countCondBlock)
 
@@ -100,15 +90,11 @@ func PreludeFilter(ctx *Context, n *mTypes.Node) value.Value {
 	ctx.block.NewStore(mTypes.I64zero, conjLoopIdxPtr)
 	ctx.block.NewStore(mTypes.I64zero, newVecIdxPtr)
 
-	condBlock := ctx.function.NewBlock(n.GetBlockName("filter.new.vec.cond", ctx.function.Blocks))
-	loopBlock := ctx.function.NewBlock(n.GetBlockName("filter.new.vec.loop", ctx.function.Blocks))
-	loopConjBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.new.vec.loop.conj", ctx.function.Blocks),
-	)
-	loopIncBlock := ctx.function.NewBlock(
-		n.GetBlockName("filter.new.vec.loop.inc", ctx.function.Blocks),
-	)
-	endBlock := ctx.function.NewBlock(n.GetBlockName("filter.new.vec.end", ctx.function.Blocks))
+	condBlock := ctx.NewBlock("filter.new.vec.cond", n)
+	loopBlock := ctx.NewBlock("filter.new.vec.loop", n)
+	loopConjBlock := ctx.NewBlock("filter.new.vec.loop.conj", n)
+	loopIncBlock := ctx.NewBlock("filter.new.vec.loop.inc", n)
+	endBlock := ctx.NewBlock("filter.new.vec.end", n)
 
 	ctx.block.NewBr(condBlock)
 

--- a/pkg/codegen/prelude_filter.go
+++ b/pkg/codegen/prelude_filter.go
@@ -31,9 +31,9 @@ func PreludeFilter(ctx *Context, n *mTypes.Node) value.Value {
 	structedVecType, elemType := mTypes.GetVectorTypeFromPtr(oldStructedVecPtr)
 
 	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
-	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)
 
 	oldVecPtr := ctx.block.NewExtractValue(oldStructedVec, 0)
+	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)
 
 	// get the number of elements for which the predicate returns true
 	// This step is necessary to allocate the correct number of bytes with malloc

--- a/pkg/codegen/prelude_map.go
+++ b/pkg/codegen/prelude_map.go
@@ -46,9 +46,9 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	loopIndexPtr := ctx.block.NewAlloca(types.I64)
 	ctx.block.NewStore(mTypes.I64zero, loopIndexPtr)
 
-	loopBlock := ctx.function.NewBlock(n.GetBlockName("map.loop", ctx.function.Blocks))
-	condBlock := ctx.function.NewBlock(n.GetBlockName("map.cond", ctx.function.Blocks))
-	endBlock := ctx.function.NewBlock(n.GetBlockName("map.end", ctx.function.Blocks))
+	loopBlock := ctx.NewBlock("map.loop", n)
+	condBlock := ctx.NewBlock("map.cond", n)
+	endBlock := ctx.NewBlock("map.end", n)
 
 	ctx.block.NewBr(condBlock)
 

--- a/pkg/codegen/prelude_map.go
+++ b/pkg/codegen/prelude_map.go
@@ -28,7 +28,7 @@ func PreludeMap(ctx *Context, n *mTypes.Node) value.Value {
 	}
 
 	oldStructedVecPtr := n.Next.IRValue
-	structedVecType := mTypes.GetStructTypeFromPtr(oldStructedVecPtr)
+	structedVecType, _ := mTypes.GetVectorTypeFromPtr(oldStructedVecPtr)
 	elemType := f.Sig.RetType
 
 	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)

--- a/pkg/codegen/prelude_nth.go
+++ b/pkg/codegen/prelude_nth.go
@@ -17,8 +17,7 @@ func PreludeNth(ctx *Context, n *mTypes.Node) value.Value {
 	idx := constant.NewInt(types.I64, i)
 
 	structedVecPtr := n.IRValue
-	structedVecType := mTypes.GetStructTypeFromPtr(structedVecPtr)
-	elemType := structedVecType.Fields[0].(*types.PointerType).ElemType
+	structedVecType, elemType := mTypes.GetVectorTypeFromPtr(structedVecPtr)
 
 	nullPtr := constant.NewNull(types.NewPointer(elemType))
 

--- a/pkg/codegen/prelude_nth.go
+++ b/pkg/codegen/prelude_nth.go
@@ -31,7 +31,7 @@ func PreludeNth(ctx *Context, n *mTypes.Node) value.Value {
 	maxIdx := ctx.block.NewSub(loadedLength, mTypes.I64one)
 
 	isIdxOutOfRange := ctx.block.NewICmp(enum.IPredSGT, idx, maxIdx)
-	isIdxOutOfRange.SetName(n.GetVarName("get.is.idx.out.of.range", ctx.block.Insts))
+	isIdxOutOfRange.SetName(n.GetVarName("get.is.idx.out.of.range"))
 
 	inRangeBlock := ctx.NewBlock("get.idx.in.range", n)
 	outOfRangeBlock := ctx.NewBlock("get.idx.out.of.range", n)

--- a/pkg/codegen/prelude_nth.go
+++ b/pkg/codegen/prelude_nth.go
@@ -34,11 +34,9 @@ func PreludeNth(ctx *Context, n *mTypes.Node) value.Value {
 	isIdxOutOfRange := ctx.block.NewICmp(enum.IPredSGT, idx, maxIdx)
 	isIdxOutOfRange.SetName(n.GetVarName("get.is.idx.out.of.range", ctx.block.Insts))
 
-	inRangeBlock := ctx.function.NewBlock(n.GetBlockName("get.idx.in.range", ctx.function.Blocks))
-	outOfRangeBlock := ctx.function.NewBlock(
-		n.GetBlockName("get.idx.out.of.range", ctx.function.Blocks),
-	)
-	mergeBlock := ctx.function.NewBlock(n.GetBlockName("get.idx.merge", ctx.function.Blocks))
+	inRangeBlock := ctx.NewBlock("get.idx.in.range", n)
+	outOfRangeBlock := ctx.NewBlock("get.idx.out.of.range", n)
+	mergeBlock := ctx.NewBlock("get.idx.merge", n)
 
 	ctx.block.NewCondBr(isIdxOutOfRange, outOfRangeBlock, inRangeBlock)
 

--- a/pkg/codegen/prelude_prn.go
+++ b/pkg/codegen/prelude_prn.go
@@ -98,8 +98,7 @@ func prnStructVector(
 ) {
 	v := n.IRValue
 
-	ty := mTypes.GetStructTypeFromPtr(v)
-	elemTy := ty.Fields[0].(*types.PointerType).ElemType
+	ty, elemTy := mTypes.GetVectorTypeFromPtr(v)
 
 	_, nonNullBlock, endBlock := genNilBlock(ctx, types.NewPointer(ty), n, v)
 

--- a/pkg/codegen/prelude_prn.go
+++ b/pkg/codegen/prelude_prn.go
@@ -113,7 +113,7 @@ func prnStructVector(
 
 	// インデックスの初期化
 	idx := nonNullBlock.NewAlloca(types.I64)
-	idx.SetName(n.GetVarName("prn.cur.idx", nonNullBlock.Insts))
+	idx.SetName(n.GetVarName("prn.cur.idx"))
 	nonNullBlock.NewStore(mTypes.I64zero, idx)
 
 	loopBlock := ctx.NewBlock("prn.vec.loop.enter", n)

--- a/pkg/codegen/prelude_prn.go
+++ b/pkg/codegen/prelude_prn.go
@@ -25,7 +25,7 @@ func genNilBlock(
 	)
 
 	// if value is null ptr
-	nullBlock := ctx.function.NewBlock(n.GetBlockName("prn.null", ctx.function.Blocks))
+	nullBlock := ctx.NewBlock("prn.null", n)
 	nullBlock.NewCall(
 		ctx.internal.Cstd.Printf,
 		ctx.internal.GlobalConst.FormatStr,
@@ -33,9 +33,9 @@ func genNilBlock(
 	)
 
 	// if value is not null ptr
-	nonNullBlock := ctx.function.NewBlock(n.GetBlockName("prn.non.null", ctx.function.Blocks))
+	nonNullBlock := ctx.NewBlock("prn.non.null", n)
 
-	endBlock := ctx.function.NewBlock(n.GetBlockName("prn.exit", ctx.function.Blocks))
+	endBlock := ctx.NewBlock("prn.exit", n)
 	nullBlock.NewBr(endBlock)
 	nonNullBlock.NewBr(endBlock)
 
@@ -117,9 +117,9 @@ func prnStructVector(
 	idx.SetName(n.GetVarName("prn.cur.idx", nonNullBlock.Insts))
 	nonNullBlock.NewStore(mTypes.I64zero, idx)
 
-	loopBlock := ctx.function.NewBlock(n.GetBlockName("prn.vec.loop.enter", ctx.function.Blocks))
-	continueBlock := ctx.function.NewBlock(n.GetBlockName("prn.vec.continue", ctx.function.Blocks))
-	loopEndBlock := ctx.function.NewBlock(n.GetBlockName("prn.vec.loop.exit", ctx.function.Blocks))
+	loopBlock := ctx.NewBlock("prn.vec.loop.enter", n)
+	continueBlock := ctx.NewBlock("prn.vec.continue", n)
+	loopEndBlock := ctx.NewBlock("prn.vec.loop.exit", n)
 
 	nonNullBlock.NewCall(
 		ctx.internal.Cstd.Printf,

--- a/pkg/codegen/prelude_prn.go
+++ b/pkg/codegen/prelude_prn.go
@@ -102,23 +102,19 @@ func prnStructVector(
 
 	_, nonNullBlock, endBlock := genNilBlock(ctx, types.NewPointer(ty), n, v)
 
-	// if value is not null ptr
-
 	formatStr, _ := mTypes.GetPrintFormat(elemTy, ctx.internal)
-	loaded := nonNullBlock.NewLoad(ty, n.IRValue)
+	structedVec := nonNullBlock.NewLoad(ty, n.IRValue)
 
-	// 構造体のフィールドから arrPtr と len を取り出す
-	resultArrPtr := nonNullBlock.NewExtractValue(loaded, 0)
-	resultLen := nonNullBlock.NewExtractValue(loaded, 1)
+	vecPtr := nonNullBlock.NewExtractValue(structedVec, 0)
+	vecLenPtr := nonNullBlock.NewExtractValue(structedVec, 1)
 
-	// インデックスの初期化
-	idx := nonNullBlock.NewAlloca(types.I64)
-	idx.SetName(n.GetVarName("prn.cur.idx"))
-	nonNullBlock.NewStore(mTypes.I64zero, idx)
+	loopIdxPtr := nonNullBlock.NewAlloca(types.I64)
+	loopIdxPtr.SetName(n.GetVarName("prn.cur.idx"))
+	nonNullBlock.NewStore(mTypes.I64zero, loopIdxPtr)
 
-	loopBlock := ctx.NewBlock("prn.vec.loop.enter", n)
-	continueBlock := ctx.NewBlock("prn.vec.continue", n)
-	loopEndBlock := ctx.NewBlock("prn.vec.loop.exit", n)
+	loopBlock := ctx.NewBlock("prn.vec.loop", n)
+	condBlock := ctx.NewBlock("prn.vec.cond", n)
+	exitBlock := ctx.NewBlock("prn.vec.exit", n)
 
 	nonNullBlock.NewCall(
 		ctx.internal.Cstd.Printf,
@@ -126,12 +122,9 @@ func prnStructVector(
 	)
 	nonNullBlock.NewBr(loopBlock)
 
-	// ループ内部の処理
-	// i をロード
-	i := loopBlock.NewLoad(types.I64, idx)
+	loopIdx := loopBlock.NewLoad(types.I64, loopIdxPtr)
 
-	// 配列の各要素を取り出して表示
-	elemPtr := loopBlock.NewGetElementPtr(elemTy, resultArrPtr, i)
+	elemPtr := loopBlock.NewGetElementPtr(elemTy, vecPtr, loopIdx)
 	elem := loopBlock.NewLoad(elemTy, elemPtr)
 
 	if elem.ElemType == types.I1 {
@@ -151,28 +144,27 @@ func prnStructVector(
 	}
 
 	// i++
-	nextI := loopBlock.NewAdd(i, mTypes.I64one)
-	loopBlock.NewStore(nextI, idx)
+	nextIdx := loopBlock.NewAdd(loopIdx, mTypes.I64one)
+	loopBlock.NewStore(nextIdx, loopIdxPtr)
 
-	continueBlock.NewCall(
+	condBlock.NewCall(
 		ctx.internal.Cstd.Printf,
 		ctx.internal.GlobalConst.StringComma,
 	)
-	continueBlock.NewCall(
+	condBlock.NewCall(
 		ctx.internal.Cstd.Printf,
 		ctx.internal.GlobalConst.StringSpace,
 	)
-	continueBlock.NewBr(loopBlock)
+	condBlock.NewBr(loopBlock)
 
-	// i < len ?
-	cond := loopBlock.NewICmp(enum.IPredSLT, nextI, resultLen)
-	loopBlock.NewCondBr(cond, continueBlock, loopEndBlock)
-	loopEndBlock.NewCall(
+	cond := loopBlock.NewICmp(enum.IPredULT, nextIdx, vecLenPtr)
+	loopBlock.NewCondBr(cond, condBlock, exitBlock)
+	exitBlock.NewCall(
 		ctx.internal.Cstd.Printf,
 		ctx.internal.GlobalConst.StringBracketClose,
 	)
 
-	loopEndBlock.NewBr(endBlock)
+	exitBlock.NewBr(endBlock)
 
 	ctx.block = endBlock
 }

--- a/pkg/codegen/prelude_vector.go
+++ b/pkg/codegen/prelude_vector.go
@@ -39,8 +39,8 @@ func CopyVector(
 	isIdxLTOldLen := condBlock.NewICmp(enum.IPredULT, loopIdx, oldLen)
 	condBlock.NewCondBr(isIdxLTOldLen, loopBlock, endBlock)
 
-	oldArrElemPtr := loopBlock.NewGetElementPtr(elemType, oldVecPtr, loopIdx)
-	oldElem := loopBlock.NewLoad(elemType, oldArrElemPtr)
+	oldElemPtr := loopBlock.NewGetElementPtr(elemType, oldVecPtr, loopIdx)
+	oldElem := loopBlock.NewLoad(elemType, oldElemPtr)
 	newVecElemPtr := loopBlock.NewGetElementPtr(elemType, newVecPtr, loopIdx)
 	loopBlock.NewStore(oldElem, newVecElemPtr)
 

--- a/pkg/codegen/prelude_vector.go
+++ b/pkg/codegen/prelude_vector.go
@@ -29,9 +29,9 @@ func CopyVector(
 	loopIndexPtr := ctx.block.NewAlloca(types.I64)
 	ctx.block.NewStore(mTypes.I64zero, loopIndexPtr)
 
-	loopBlock := ctx.function.NewBlock(n.GetBlockName("copy.loop", ctx.function.Blocks))
-	condBlock := ctx.function.NewBlock(n.GetBlockName("copy.cond", ctx.function.Blocks))
-	endBlock := ctx.function.NewBlock(n.GetBlockName("copy.end", ctx.function.Blocks))
+	loopBlock := ctx.NewBlock("copy.loop", n)
+	condBlock := ctx.NewBlock("copy.cond", n)
+	endBlock := ctx.NewBlock("copy.end", n)
 
 	ctx.block.NewBr(condBlock)
 

--- a/pkg/types/ir.go
+++ b/pkg/types/ir.go
@@ -149,7 +149,10 @@ func GetBitWidth(t types.Type) uint64 {
 	}
 }
 
-func GetStructTypeFromPtr(v value.Value) *types.StructType {
+func GetVectorTypeFromPtr(v value.Value) (*types.StructType, types.Type) {
 	structPtr := v.Type().(*types.PointerType)
-	return structPtr.ElemType.(*types.StructType)
+	structedVecType := structPtr.ElemType.(*types.StructType)
+	elemType := structedVecType.Fields[0].(*types.PointerType).ElemType
+
+	return structedVecType, elemType
 }

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -137,7 +137,7 @@ func (node *Node) GetFuncName() string {
 	return fmt.Sprintf("fn.%s", node.Val)
 }
 
-func (node *Node) GetVarName(s string, insts []ir.Instruction) string {
+func (node *Node) GetVarName(s string) string {
 	return fmt.Sprintf("%s.%p", s, node)
 }
 

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -137,10 +137,6 @@ func (node *Node) GetFuncName() string {
 	return fmt.Sprintf("fn.%s", node.Val)
 }
 
-func (node *Node) GetBlockName(s string, blks []*ir.Block) string {
-	return fmt.Sprintf("%s.%p.%d", s, node, len(blks))
-}
-
 func (node *Node) GetVarName(s string, insts []ir.Instruction) string {
 	return fmt.Sprintf("%s.%p", s, node)
 }

--- a/pkg/types/node_test.go
+++ b/pkg/types/node_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/llir/llvm/ir"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,14 +17,6 @@ func TestGetFuncNameUnnamed(t *testing.T) {
 	node := &Node{}
 	want := "fn.unnamed." + fmt.Sprintf("%p", node)
 	assert.Equal(t, want, node.GetUnnamedFuncName())
-}
-
-func TestGetBlockName(t *testing.T) {
-	node := &Node{}
-	blockName := "block"
-	var blks = []*ir.Block{&ir.Block{}, &ir.Block{}}
-	want := blockName + "." + fmt.Sprintf("%p", node) + ".2"
-	assert.Equal(t, want, node.GetBlockName(blockName, blks))
 }
 
 func add(kind NodeKind, val string) *Node {


### PR DESCRIPTION
## What’s this PR?

## What’s changed?

- share naming logic of NewBlock
- remove dead argument on GetVarName
- change var name
- let GetVectorTypeFromPtr return also elemTyp


## Anything else?
