### PR TITLE
Feature/let operators taking exactly 2 args

### DIFF
--- a/pkg/codegen/prelude_operator.go
+++ b/pkg/codegen/prelude_operator.go
@@ -10,34 +10,18 @@ import (
 
 // arithmetic
 func PreludeAdd(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldArithmetic(
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewAdd(x, y)
-		})
+	return ctx.block.NewAdd(node.IRValue, node.Next.IRValue)
 }
 
 func PreludeSub(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldArithmetic(
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewSub(x, y)
-		})
+	return ctx.block.NewSub(node.IRValue, node.Next.IRValue)
 }
 
 func PreludeMul(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldArithmetic(
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewMul(x, y)
-		})
+	return ctx.block.NewMul(node.IRValue, node.Next.IRValue)
 }
 func PreludeDiv(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldArithmetic(
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewSDiv(x, y)
-		})
+	return ctx.block.NewSDiv(node.IRValue, node.Next.IRValue)
 }
 
 func PreludeMod(ctx *Context, node *mTypes.Node) value.Value {
@@ -56,57 +40,23 @@ func PreludeEq(ctx *Context, node *mTypes.Node) value.Value {
 
 		cmpRes := ctx.block.NewCall(ctx.internal.Cstd.Strcmp, fst, snd)
 		isEq := ctx.block.NewICmp(enum.IPredEQ, cmpRes, mTypes.I1zero)
-		res := ctx.block.NewAnd(isEq, mTypes.I1one)
-
-		for n := node.Next; n != nil; n = n.Next {
-			snd = n.IRValue
-			cmpRes = ctx.block.NewCall(ctx.internal.Cstd.Strcmp, fst, snd)
-			isEq = ctx.block.NewICmp(enum.IPredEQ, cmpRes, mTypes.I1zero)
-			res = ctx.block.NewAnd(res, isEq)
-		}
-		return res
+		return ctx.block.NewAnd(isEq, mTypes.I1one)
 
 	} else {
-		return invokeFoldPred(
-			ctx.block,
-			node,
-			func(x, y value.Value) value.Value {
-				return ctx.block.NewICmp(enum.IPredEQ, x, y)
-			})
-
+		return ctx.block.NewICmp(enum.IPredEQ, node.IRValue, node.Next.IRValue)
 	}
 }
 func PreludeGt(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldPred(
-		ctx.block,
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewICmp(enum.IPredSGT, x, y)
-		})
+	return ctx.block.NewICmp(enum.IPredSGT, node.IRValue, node.Next.IRValue)
 }
 func PreludeLt(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldPred(
-		ctx.block,
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewICmp(enum.IPredSLT, x, y)
-		})
+	return ctx.block.NewICmp(enum.IPredSLT, node.IRValue, node.Next.IRValue)
 }
 
 // logical
 func PreludeAnd(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldPred(
-		ctx.block,
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewAnd(x, y)
-		})
+	return ctx.block.NewAnd(node.IRValue, node.Next.IRValue)
 }
 func PreludeOr(ctx *Context, node *mTypes.Node) value.Value {
-	return invokeFoldPred(
-		ctx.block,
-		node,
-		func(x, y value.Value) value.Value {
-			return ctx.block.NewOr(x, y)
-		})
+	return ctx.block.NewOr(node.IRValue, node.Next.IRValue)
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -55,6 +55,7 @@ func parseBody(
 ) (*mTypes.Token, *mTypes.Node) {
 
 	nextToken, argHead := parseExprs(rootToken.Next, parentKind)
+	// Note: validate argument properties here?
 	rootNode := newNodeParent(parentKind, argHead, exprName)
 	return nextToken, rootNode
 }

--- a/script/test-full.sh
+++ b/script/test-full.sh
@@ -8,11 +8,11 @@ testexec(){
   assertexec '(def main ::int (fn [] (prn 17)))' "17\\\n"
   # arithmetic operator
   echo "== arithmetic operator ==="
-  assertexec '(def main ::int (fn [] (prn (+ 1 2 3 4 5 20))))' "35\\\n"
-  assertexec '(def main ::int (fn [] (prn (+ 1 2 (+ 3 4)))))' "10\\\n"
+  assertexec '(def main ::int (fn [] (prn (+ 15 20))))' "35\\\n"
+  assertexec '(def main ::int (fn [] (prn (+ 1 (+ 3 6)))))' "10\\\n"
   assertexec '(def main ::int (fn [] (prn (+ (+ 1 2) (+ 3 4)))))' "10\\\n"
   assertexec '(def main ::int (fn [] (prn (+ (+ 1 2) (+ (+ 9 5) 4)))))' "21\\\n"
-  assertexec '(def main ::int (fn [] (prn (+ 1 (+ 3 2) (+ (+ 9 4 5) 7 8)))))' "39\\\n"
+  assertexec '(def main ::int (fn [] (prn (+ 1 (+ (+ 4 5) 8)))))' "18\\\n"
 
   assertexec '(def main ::int (fn [] (prn (mod 20 5))))' "0\\\n"
   assertexec '(def main ::int (fn [] (prn (mod 17 5))))' "2\\\n"
@@ -21,19 +21,19 @@ testexec(){
 
   assertexec '(def main ::int (fn [] (prn (* 4 5))))' "20\\\n"
   assertexec '(def main ::int (fn [] (prn (* 9 5))))' "45\\\n"
-  assertexec '(def main ::int (fn [] (prn (* 2 3 4))))' "24\\\n"
+  assertexec '(def main ::int (fn [] (prn (* 3 4))))' "12\\\n"
   assertexec '(def main ::int (fn [] (prn (* (+ 2 3) 5))))' "25\\\n"
 
   assertexec '(def main ::int (fn [] (prn (/ 4 2))))' "2\\\n"
   assertexec '(def main ::int (fn [] (prn (/ 5 2))))' "2\\\n"
-  assertexec '(def main ::int (fn [] (prn (/ 8 2 2))))' "2\\\n"
+  assertexec '(def main ::int (fn [] (prn (/ 5 0))))' "0\\\n"
+  assertexec '(def main ::int (fn [] (prn (/ 0 5))))' "0\\\n"
 
 
   # equality operator
   echo "== equality operator ==="
   assertexec '(def main ::int (fn [] (prn (= 123 123))))' "true\\\n"
-  assertexec '(def main ::int (fn [] (prn (= 123 123 123))))' "true\\\n"
-  assertexec '(def main ::int (fn [] (prn (= 123 123 456))))' "false\\\n"
+  assertexec '(def main ::int (fn [] (prn (= 123 456))))' "false\\\n"
   assertexec '(def main ::int (fn [] (prn (= 5 (+ 3 2)))))' "true\\\n"
   assertexec '(def main ::int (fn [] (prn (= (+ 4 3) (+ 3 2)))))' "false\\\n"
   assertexec '(def main ::int (fn [] (prn (= (+ 4 -3) (+ 3 -2)))))' "true\\\n"
@@ -42,12 +42,8 @@ testexec(){
   assertexec '(def main ::int (fn [] (prn (= false false))))' "true\\\n"
   assertexec '(def main ::int (fn [] (prn (= "foo" "foo"))))' "true\\\n"
   assertexec '(def main ::int (fn [] (prn (= "www" "rrr"))))' "false\\\n"
-  assertexec '(def main ::int (fn [] (prn (= "foo" "foo" "foo"))))' "true\\\n"
-  assertexec '(def main ::int (fn [] (prn (= "foo" "foo" "goo"))))' "false\\\n"
-  assertexec '(def main ::int (fn [] (prn (= "foo" "goo" "hoo"))))' "false\\\n"
   # it's unknown bug
   assertexec '(def main ::int (fn [] (prn (= "foo" "bar"))))' "true\\\n" # must be false
-  assertexec '(def main ::int (fn [] (prn (= "foo" "foo" "bar"))))' "true\\\n" # must be false
 
   assertexec '(def main ::int (fn [] (prn (> 8 2))))' "true\\\n"
   assertexec '(def main ::int (fn [] (prn (> 1 2))))' "false\\\n"
@@ -56,8 +52,6 @@ testexec(){
   assertexec '(def main ::int (fn [] (prn (< 8 2))))' "false\\\n"
   assertexec '(def main ::int (fn [] (prn (< 1 2))))' "true\\\n"
   assertexec '(def main ::int (fn [] (prn (< 2 2))))' "false\\\n"
-  assertexec '(def main ::int (fn [] (prn (< 1 2 3))))' "true\\\n"
-  assertexec '(def main ::int (fn [] (prn (< 1 2 1))))' "false\\\n"
 
   # logical operator
   echo "== logical operator ==="
@@ -75,7 +69,7 @@ testexec(){
   assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ x 2))))' "3\\\n"
   assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ 2 x))))' "3\\\n"
   assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ x (+ 2 3)))))' "6\\\n"
-  assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ x (+ 2 3) 4))))' "10\\\n"
+  assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ x (+ (+ 2 3) 4)))))' "10\\\n"
   assertexec '(def x ::int 1) (def y ::int 2) (def main ::int (fn [] (prn (+ x y))))' "3\\\n"
   assertexec '(def x ::int 1) (def main ::int (fn [] (prn (+ x x))))' "2\\\n"
 


### PR DESCRIPTION
## What’s this PR?

## What’s changed?

The operator was changed to take exactly two arguments instead of a variadic number

before: `(+ 1 2 3 4)`
after: `(+ 1 2)`

## Anything else?

