### PR TITLE
stop exiting when panic occurred in repl

### DIFF
--- a/cmd/modo/main.go
+++ b/cmd/modo/main.go
@@ -250,8 +250,14 @@ func (ctx *context) repl() {
 			line = fmt.Sprintf("(def main ::nil (fn [] (prn %s)))", line)
 		}
 
-		ctx.doRunLLI(line)
-
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Error("%s", r)
+				}
+			}()
+			ctx.doRunLLI(line)
+		}()
 	}
 
 }


### PR DESCRIPTION
## What’s this PR?

## What’s changed?
doRunLLI in repl() is immediately invoked using func() { ... }().
Inside it, defer func() { ... }() is used to recover from any panic.
The recover() call catches the panic, preventing the REPL from crashing and allowing the loop to continue.

## Anything else?
