### PR TITLE
Feature/prevent lexer from treating point as int type

### DIFF
--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -114,6 +114,39 @@ func TestLexOperationAddTakingAdd(t *testing.T) {
 
 	assert.EqualValues(t, want, Lex("(+ (+ 1 2) (+ 3 4))"))
 }
+func TestLexMatchSubstringOfTypeLiteralOnIdent(t *testing.T) {
+	tokens := []*mTypes.Token{
+		add(mTypes.TK_IDENT, "Point"),
+	}
+	want := buildToken(tokens)
+	assert.EqualValues(t, want, Lex("Point"))
+
+	tokens = []*mTypes.Token{
+		add(mTypes.TK_IDENT, "sstring"),
+	}
+	want = buildToken(tokens)
+	assert.EqualValues(t, want, Lex("sstring"))
+
+	tokens = []*mTypes.Token{
+		add(mTypes.TK_IDENT, "floating"),
+	}
+	want = buildToken(tokens)
+	assert.EqualValues(t, want, Lex("floating"))
+
+	tokens = []*mTypes.Token{
+		add(mTypes.TK_IDENT, "fbool"),
+	}
+	want = buildToken(tokens)
+	assert.EqualValues(t, want, Lex("fbool"))
+
+	tokens = []*mTypes.Token{
+		add(mTypes.TK_PAREN, "["),
+		add(mTypes.TK_IDENT, "Point"),
+		add(mTypes.TK_PAREN, "]"),
+	}
+	want = buildToken(tokens)
+	assert.EqualValues(t, want, Lex("[Point]"))
+}
 
 func TestNewTokenMap(t *testing.T) {
 	res := newTokenPattern()

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -117,6 +117,6 @@ func TestLexOperationAddTakingAdd(t *testing.T) {
 
 func TestNewTokenMap(t *testing.T) {
 	res := newTokenPattern()
-	assert.EqualValues(t, mTypes.INTEGER_REG_EXP, res.Pattern)
+	assert.EqualValues(t, mTypes.FRACTIONAL_REG_EXP, res.Pattern)
 	assert.EqualValues(t, mTypes.SYMBOL_TYPE_SIG, res.Next.Pattern)
 }

--- a/pkg/types/lex.go
+++ b/pkg/types/lex.go
@@ -102,11 +102,11 @@ var (
 	// Type signature
 	SYMBOL_TYPE_SIG   = "::"
 	SYMBOL_TYPE_ARROW = "=>"
-	SYMBOL_TYPE_INT   = "int"
-	SYMBOL_TYPE_FLOAT = "float"
-	SYMBOL_TYPE_STR   = "string"
-	SYMBOL_TYPE_NIL   = "nil"
-	SYMBOL_TYPE_BOOL  = "bool"
+	SYMBOL_TYPE_INT   = "\\bint\\b"
+	SYMBOL_TYPE_FLOAT = "\\bfloat\\b"
+	SYMBOL_TYPE_STR   = "\\bstring\\b"
+	SYMBOL_TYPE_NIL   = "\\bnil\\b"
+	SYMBOL_TYPE_BOOL  = "\\bbool\\b"
 
 	SYMBOL_TYPE_SCALAR = fmt.Sprintf(
 		"(\\b(%s|%s|%s|%s|%s)\\b)",

--- a/pkg/types/node_test.go
+++ b/pkg/types/node_test.go
@@ -44,12 +44,10 @@ func TestGetLastNode(t *testing.T) {
 }
 
 func TestGetNodeSize(t *testing.T) {
-	node := add(ND_COLLECTION, "")
 	childNode := add(ND_SCALAR, "")
-	node.Child = childNode
 	childNode.Next = add(ND_SCALAR, "")
 	childNode.Next.Next = add(ND_SCALAR, "")
 
 	want := uint64(3)
-	assert.Equal(t, want, node.GetNodeSize())
+	assert.Equal(t, want, childNode.GetNodeSize())
 }


### PR DESCRIPTION
## What’s this PR?
Fix bug where the lexer misinterprets point as an int type.

## What’s changed?

## Anything else?
