### PR TITLE
Feature/add prelude reduce function

### DIFF
--- a/pkg/codegen/prelude.go
+++ b/pkg/codegen/prelude.go
@@ -64,6 +64,7 @@ var PreludeFunction = map[string]OpFunc{
 	mTypes.PRELUDE_CONJ:   PreludeConj,
 	mTypes.PRELUDE_MAP:    PreludeMap,
 	mTypes.PRELUDE_FILTER: PreludeFilter,
+	mTypes.PRELUDE_REDUCE: PreludeReduce,
 	//mTypes.LIB_CORE_ASSOC: PreludeAssoc,
 	//mTypes.LIB_CORE_POP:   PreludePop,
 	mTypes.OPERATOR_ADD: OperatorDispatcher(mTypes.OPERATOR_ADD),

--- a/pkg/codegen/prelude_prn.go
+++ b/pkg/codegen/prelude_prn.go
@@ -74,12 +74,7 @@ func prnScalar(
 
 			formatStr, _ = mTypes.GetPrintFormat(pointerElemTy.ElemType, ctx.internal)
 
-			ptr := nonNullBlock.NewLoad(pointerElemTy, value)
-			value = nonNullBlock.NewGetElementPtr(
-				pointerElemTy.ElemType,
-				ptr,
-				mTypes.I32zero,
-			)
+			value := nonNullBlock.NewLoad(pointerElemTy.ElemType, value)
 
 			nonNullBlock.NewCall(ctx.internal.Cstd.Printf, formatStr, value)
 

--- a/pkg/codegen/prelude_reduce.go
+++ b/pkg/codegen/prelude_reduce.go
@@ -1,0 +1,86 @@
+package codegen
+
+import (
+	"github.com/llir/llvm/ir"
+	"github.com/llir/llvm/ir/constant"
+	"github.com/llir/llvm/ir/enum"
+	"github.com/llir/llvm/ir/types"
+	"github.com/llir/llvm/ir/value"
+
+	"github.com/wf001/modo/pkg/error"
+	"github.com/wf001/modo/pkg/log"
+	mTypes "github.com/wf001/modo/pkg/types"
+)
+
+func PreludeReduce(ctx *Context, n *mTypes.Node) value.Value {
+	if !n.IsKind(mTypes.ND_VAR_REFERENCE) {
+		log.Panic("%s: unexpected character used", error.ERROR_SYNTAX_ERROR)
+	}
+	var f *ir.Func
+
+	// find declared function
+	// TODO: find also in prelude function
+	for i := 0; i < len(ctx.mod.Funcs); i = i + 1 {
+		if ctx.mod.Funcs[i].GlobalName == n.GetFuncName() {
+			f = ctx.mod.Funcs[i]
+			break
+		}
+	}
+
+	initialValue := n.Next.IRValue
+	oldStructedVecPtr := n.Next.Next.IRValue
+
+	structedVecType, _ := mTypes.GetVectorTypeFromPtr(oldStructedVecPtr)
+	elemType := f.Sig.RetType
+
+	oldStructedVec := ctx.block.NewLoad(structedVecType, oldStructedVecPtr)
+	oldLen := ctx.block.NewExtractValue(oldStructedVec, 1)
+
+	oldVecPtr := ctx.block.NewExtractValue(oldStructedVec, 0)
+
+	elemSize := constant.NewInt(types.I64, int64(mTypes.GetBitWidth(elemType)))
+
+	newAllocPtr := ctx.block.NewCall(ctx.internal.Cstd.Malloc, elemSize)
+	newPtr := ctx.block.NewBitCast(newAllocPtr, types.NewPointer(elemType))
+
+	loopIndexPtr := ctx.block.NewAlloca(types.I64)
+	ctx.block.NewStore(mTypes.I64zero, loopIndexPtr)
+
+	condBlock := ctx.NewBlock("reduce.cond", n)
+	loopBlock := ctx.NewBlock("reduce.loop", n)
+	endBlock := ctx.NewBlock("reduce.end", n)
+
+	// f(initialValue, v[0])
+	loopIdx := ctx.block.NewLoad(types.I64, loopIndexPtr)
+	oldArrElemPtr := ctx.block.NewGetElementPtr(elemType, oldVecPtr, loopIdx)
+	oldElem := ctx.block.NewLoad(elemType, oldArrElemPtr)
+	result1 := ctx.block.NewCall(f, initialValue, oldElem)
+	ctx.block.NewStore(result1, newPtr)
+	ctx.block.NewStore(
+		ctx.block.NewAdd(loopIdx, mTypes.I64one),
+		loopIndexPtr,
+	)
+	ctx.block.NewBr(condBlock)
+
+	// loop start
+	loopIdx = condBlock.NewLoad(types.I64, loopIndexPtr)
+	isIdxLTOldLen := condBlock.NewICmp(enum.IPredULT, loopIdx, oldLen)
+	condBlock.NewCondBr(isIdxLTOldLen, loopBlock, endBlock)
+
+	oldArrElemPtr = loopBlock.NewGetElementPtr(elemType, oldVecPtr, loopIdx)
+	oldElem = loopBlock.NewLoad(elemType, oldArrElemPtr)
+	prevResult := loopBlock.NewLoad(elemType, newPtr)
+	result1 = loopBlock.NewCall(f, prevResult, oldElem)
+	loopBlock.NewStore(result1, newPtr)
+
+	loopBlock.NewStore(
+		loopBlock.NewAdd(loopIdx, mTypes.I64one),
+		loopIndexPtr,
+	)
+	loopBlock.NewBr(condBlock)
+
+	ctx.block = endBlock
+	// loop end
+
+	return newPtr
+}

--- a/pkg/types/lex.go
+++ b/pkg/types/lex.go
@@ -87,8 +87,9 @@ var (
 	PRELUDE_POP              = "pop"
 	PRELUDE_MAP              = "map"
 	PRELUDE_FILTER           = "filter"
+	PRELUDE_REDUCE           = "reduce"
 	PRELUDE_FUNCTION_REG_EXP = fmt.Sprintf(
-		"\\b(%s|%s|%s|%s|%s|%s|%s|%s)\\b",
+		"\\b(%s|%s|%s|%s|%s|%s|%s|%s|%s)\\b",
 		PRELUDE_PRN,
 		PRELUDE_GET,
 		PRELUDE_NTH,
@@ -97,6 +98,7 @@ var (
 		PRELUDE_POP,
 		PRELUDE_MAP,
 		PRELUDE_FILTER,
+		PRELUDE_REDUCE,
 	)
 
 	// Type signature

--- a/script/test-full.sh
+++ b/script/test-full.sh
@@ -313,6 +313,12 @@ testexec(){
   assertexec '(def isThreeOne :: float => bool (fn [x] (= 3.1 x))) (def main :: int (fn [] (prn (filter isThreeOne [1.1 2.1 3.1]))))' "[3.100000]\\\n"
 
   echo "==================="
+  echo "== reduce ==="
+  echo "==================="
+  assertexec '(def f :: int => int => int (fn [x y] (+ x y))) (def main :: int (fn [] (prn (reduce f 0 [3 2 1 9]))))' "15\\\n"
+  assertexec '(def f :: float => float => float (fn [x y] (+ x y))) (def main :: int (fn [] (prn (reduce f 0.1 [1.2 2.2 8.1 3.2])))))' "14.799999\\\n"
+
+  echo "==================="
   echo "== nth ==="
   echo "==================="
   # nth


### PR DESCRIPTION
## What’s this PR?

## What’s changed?
- add `reduce` function used like `reduce f x [a b c]`
- pass loaded pointer element type to printf

## Anything else?
The `reduce` of this version must pass initial value