### PR TITLE
Feature/avoid function call unnecessarily in ho func

### DIFF
--- a/pkg/codegen/codegen.go
+++ b/pkg/codegen/codegen.go
@@ -395,6 +395,9 @@ func (ctx *Context) genVarReference(node *mTypes.Node) value.Value {
 	// find in global variable which is declared with def
 	for declare := ctx.prog.Declare.Func; declare != nil; declare = declare.Next {
 		if declare.Child.Val == node.Val {
+			if declare.Child.Child.Kind == mTypes.ND_LAMBDA {
+				return declare.Child.FuncPtr
+			}
 			return ctx.block.NewCall(declare.Child.FuncPtr)
 		}
 	}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -58,6 +58,7 @@ func parseBody(
 	nextToken, argHead := parseExprs(rootToken.Next, parentKind)
 	// Note: validate argument properties here?
 	rootNode := newNodeParent(parentKind, argHead, exprName)
+	rootNode.IsHOFunc = mTypes.IsHOLibFunc(rootNode.Val)
 	return nextToken, rootNode
 }
 
@@ -438,11 +439,53 @@ func parseProgram(tok *mTypes.Token) *mTypes.Program {
 	return p
 }
 
+func findVarDeclareNode(root *mTypes.Node, target *mTypes.Node) *mTypes.Node {
+	if root == nil {
+		return nil
+	}
+	if root != target &&
+		root.Kind == mTypes.ND_VAR_DECLARE &&
+		root.Val == target.Val {
+		return root
+	}
+	if res := findVarDeclareNode(root.Next, target); res != nil {
+		return res
+	}
+	if res := findVarDeclareNode(root.Child, target); res != nil {
+		return res
+	}
+	if res := findVarDeclareNode(root.Bind, target); res != nil {
+		return res
+	}
+	return nil
+}
+
+func updateReferenceToFunccall(node *mTypes.Node, parent *mTypes.Node, root *mTypes.Node) {
+	if node == nil {
+		return
+	}
+	if node.Kind == mTypes.ND_VAR_REFERENCE {
+		if decl := findVarDeclareNode(root, node); decl != nil {
+			if decl.Child != nil && decl.Child.IsKind(mTypes.ND_LAMBDA) && !parent.IsHOFunc {
+				node.Kind = mTypes.ND_FUNCCALL
+			} else {
+				node.Type = decl.Type
+			}
+		}
+	}
+	updateReferenceToFunccall(node.Next, parent, root)
+	updateReferenceToFunccall(node.Child, node, root)
+	updateReferenceToFunccall(node.Bind, parent, root)
+}
+
 // take Token object, return Program object
 func Parse(token *mTypes.Token) *mTypes.Program {
 	log.DebugMessage("code parsing")
 	prog := parseProgram(token)
 	log.DebugMessage("code parsed")
+	for d := prog.Declare.Func; d != nil; d = d.Next {
+		updateReferenceToFunccall(d.Child, d, prog.Declare.Func)
+	}
 
 	prog.Debug(0)
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -464,9 +464,9 @@ func updateReferenceToFunccall(node *mTypes.Node, parent *mTypes.Node, root *mTy
 	if node == nil {
 		return
 	}
-	if node.Kind == mTypes.ND_VAR_REFERENCE {
+	if node.Kind == mTypes.ND_VAR_REFERENCE && !parent.IsHOFunc {
 		if decl := findVarDeclareNode(root, node); decl != nil {
-			if decl.Child != nil && decl.Child.IsKind(mTypes.ND_LAMBDA) && !parent.IsHOFunc {
+			if decl.Child != nil && decl.Child.IsKind(mTypes.ND_LAMBDA) {
 				node.Kind = mTypes.ND_FUNCCALL
 			} else {
 				node.Type = decl.Type

--- a/pkg/types/lex.go
+++ b/pkg/types/lex.go
@@ -150,3 +150,9 @@ var (
 		),
 	)
 )
+
+func IsHOLibFunc(f string) bool {
+	return f == PRELUDE_MAP ||
+		f == PRELUDE_FILTER ||
+		f == PRELUDE_REDUCE
+}

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -85,6 +85,7 @@ type Node struct {
 	Bind     *Node
 	Args     *Node
 	IsGlobal bool
+	IsHOFunc bool
 	FuncPtr  *ir.Func    // declared function, library function
 	IRValue  value.Value //
 }

--- a/pkg/types/node.go
+++ b/pkg/types/node.go
@@ -84,10 +84,10 @@ type Node struct {
 	Len      uint64 // the number of bytes, used with string type
 	Bind     *Node
 	Args     *Node
-	IsGlobal bool
-	IsHOFunc bool
-	FuncPtr  *ir.Func    // declared function, library function
-	IRValue  value.Value //
+	IsGlobal bool        // a global variable or not, used with only string type
+	IsHOFunc bool        // a High-Order function or not
+	FuncPtr  *ir.Func    // a declared function pointer, or library function pointer
+	IRValue  value.Value // a llir/llvm value. this field is set by codegen.
 }
 
 func (n *Node) String() string {


### PR DESCRIPTION
## What’s this PR?

## What’s changed?
- update the node kind of 0-arity function call from nd.var-reference to nd.funcall
``` clojure
(def f::[int] => [int]
 (fn[v]
  (conj v 32)))

(def g::[int] [12, 34, 56])

(def h::[int]
 (fn[]
  [78, 90]))

(def inc::int => int
 (fn[x]
  (+ x 1)))

(def main ::int
  (fn[]
    (let [v ::[int] [42, 64, 90]]
      (prn (f v))
      (prn g)
      (prn h)
      (prn v)
      (prn (map inc [11, 12, 13]))
      )))
```

`before`
```
DEBUG            [.Child]                  file=node.go func=types.indicate line=256
DEBUG            {Kind:"nd.expr", Val:"", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.funccall", Val:"f", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.var.reference", Val:"v", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.var.reference", Val:"g", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.var.reference", Val:"h", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.var.reference", Val:"v", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.libcall", Val:"map", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.var.reference", Val:"inc", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.collection", Val:"", Type:{Value: "vector", ExtendName: "", Child: "{Value: "int", ExtendName: "" }" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"11", Type:{Value: "int", ExtendName: "" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"12", Type:{Value: "int", ExtendName: "" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"13", Type:{Value: "int", ExtendName: "" },  Len:0}

```
`after`
```
DEBUG            [.Child]                  file=node.go func=types.indicate line=257
DEBUG            {Kind:"nd.expr", Val:"", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.funccall", Val:"f", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.var.reference", Val:"v", Type:{Value: "vector", ExtendName: "", Child: "{Value: "int", ExtendName: "" }" },  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.var.reference", Val:"g", Type:{Value: "vector", ExtendName: "", Child: "{Value: "int", ExtendName: "" }" },  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.funccall", Val:"h", Type:<nil>,  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.var.reference", Val:"v", Type:{Value: "vector", ExtendName: "", Child: "{Value: "int", ExtendName: "" }" },  Len:0}
DEBUG              {Kind:"nd.libcall", Val:"prn", Type:<nil>,  Len:0}
DEBUG                {Kind:"nd.libcall", Val:"map", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.var.reference", Val:"inc", Type:<nil>,  Len:0}
DEBUG                  {Kind:"nd.collection", Val:"", Type:{Value: "vector", ExtendName: "", Child: "{Value: "int", ExtendName: "" }" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"11", Type:{Value: "int", ExtendName: "" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"12", Type:{Value: "int", ExtendName: "" },  Len:0}
DEBUG                    {Kind:"nd.scalar", Val:"13", Type:{Value: "int", ExtendName: "" },  Len:0}
```
- avoid function call unnecessarily in high-order func
``` clojure
(def conjw :: double => double
  (fn [x]
    (+ x 1.1)))

(def main :: int
  (fn []
    (prn (map conjw [3.2 5.4]))
    ))
```

``` llvm
define i32 @main() {
0:
        call void @fn.unnamed.0x14000161170()
        ret i32 0
}

define void @fn.unnamed.0x14000161170() {
fn.entry.0x14000161170.0:
        %0 = call double @fn.conjw() <- remove
        %1 = mul i64 64, 2
        %2 = call i8* @malloc(i64 %1)
```

## Anything else?

Optional: anything reviewers should pay attention to.
